### PR TITLE
Phase 2D: Interactive widgets with PostToMagnetIntent

### DIFF
--- a/ios/Magnets.xcodeproj/project.pbxproj
+++ b/ios/Magnets.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		AD0000000000000000000029 /* SmallWidgetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC0000000000000000000025 /* SmallWidgetView.swift */; };
 		AD000000000000000000002A /* MediumWidgetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC0000000000000000000026 /* MediumWidgetView.swift */; };
 		AD000000000000000000002B /* LargeWidgetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC0000000000000000000027 /* LargeWidgetView.swift */; };
+		AD000000000000000000002C /* PostToMagnetIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC000000000000000000002A /* PostToMagnetIntent.swift */; };
 		AD0000000000000000000030 /* MagnetsWidget.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = AC0000000000000000000002 /* MagnetsWidget.appex */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 /* End PBXBuildFile section */
 
@@ -81,6 +82,7 @@
 		AC0000000000000000000027 /* LargeWidgetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeWidgetView.swift; sourceTree = "<group>"; };
 		AC0000000000000000000028 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		AC0000000000000000000029 /* MagnetsWidget.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = MagnetsWidget.entitlements; sourceTree = "<group>"; };
+		AC000000000000000000002A /* PostToMagnetIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostToMagnetIntent.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -162,6 +164,7 @@
 				AC0000000000000000000022 /* MagnetsWidgetBundle.swift */,
 				AC0000000000000000000023 /* Provider.swift */,
 				AC0000000000000000000024 /* WidgetPushHandler.swift */,
+				AB0000000000000000000008 /* Intents */,
 				AB0000000000000000000007 /* WidgetViews */,
 				AC0000000000000000000028 /* Info.plist */,
 				AC0000000000000000000029 /* MagnetsWidget.entitlements */,
@@ -177,6 +180,14 @@
 				AC0000000000000000000027 /* LargeWidgetView.swift */,
 			);
 			path = WidgetViews;
+			sourceTree = "<group>";
+		};
+		AB0000000000000000000008 /* Intents */ = {
+			isa = PBXGroup;
+			children = (
+				AC000000000000000000002A /* PostToMagnetIntent.swift */,
+			);
+			path = Intents;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -321,6 +332,7 @@
 				AD0000000000000000000029 /* SmallWidgetView.swift in Sources */,
 				AD000000000000000000002A /* MediumWidgetView.swift in Sources */,
 				AD000000000000000000002B /* LargeWidgetView.swift in Sources */,
+				AD000000000000000000002C /* PostToMagnetIntent.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/MagnetsWidget/Intents/PostToMagnetIntent.swift
+++ b/ios/MagnetsWidget/Intents/PostToMagnetIntent.swift
@@ -1,0 +1,66 @@
+import AppIntents
+import Foundation
+import SwiftData
+import WidgetKit
+
+struct PostToMagnetIntent: AppIntent {
+    static let title: LocalizedStringResource = "Post to Magnet"
+    static let description = IntentDescription("Adds a quick preset post to a Magnet without opening the app.")
+    static let openAppWhenRun = false
+    static let isDiscoverable = false
+
+    @Parameter(title: "Magnet ID")
+    var magnetID: String
+
+    @Parameter(title: "Quick Message")
+    var quickMessage: String
+
+    init() {}
+
+    init(magnetID: String, quickMessage: String) {
+        self.magnetID = magnetID
+        self.quickMessage = quickMessage
+    }
+
+    @MainActor
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        let trimmedMessage = quickMessage.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !trimmedMessage.isEmpty else {
+            return .result(dialog: IntentDialog("Quick post was empty."))
+        }
+
+        guard let magnetUUID = UUID(uuidString: magnetID) else {
+            return .result(dialog: IntentDialog("That Magnet is unavailable right now."))
+        }
+
+        do {
+            let container = try SharedModelContainer.makeContainer()
+            let context = ModelContext(container)
+            let descriptor = FetchDescriptor<Magnet>(
+                predicate: #Predicate { magnet in
+                    magnet.id == magnetUUID
+                }
+            )
+
+            guard let magnet = try context.fetch(descriptor).first else {
+                return .result(dialog: IntentDialog("That Magnet could not be found."))
+            }
+
+            let post = Post(
+                contentType: .text,
+                textContent: trimmedMessage,
+                backgroundColor: MagnetPalette.randomPostHex(),
+                magnet: magnet
+            )
+
+            context.insert(post)
+            try context.save()
+            WidgetCenter.shared.reloadAllTimelines()
+
+            return .result(dialog: IntentDialog("Posted \(trimmedMessage) to \(magnet.name)."))
+        } catch {
+            return .result(dialog: IntentDialog("Couldn't post right now."))
+        }
+    }
+}

--- a/ios/MagnetsWidget/WidgetViews/LargeWidgetView.swift
+++ b/ios/MagnetsWidget/WidgetViews/LargeWidgetView.swift
@@ -1,3 +1,4 @@
+import AppIntents
 import SwiftUI
 import WidgetKit
 
@@ -44,6 +45,12 @@ struct LargeWidgetView: View {
                     }
                 }
             }
+
+            Spacer(minLength: 0)
+
+            if let magnetID = entry.magnetID {
+                quickPostActions(for: magnetID)
+            }
         }
         .padding(18)
         .containerBackground(for: .widget) {
@@ -56,6 +63,59 @@ struct LargeWidgetView: View {
                 endPoint: .bottomTrailing
             )
         }
+    }
+
+    private func quickPostActions(for magnetID: UUID) -> some View {
+        HStack(spacing: 10) {
+            quickPostButton(
+                magnetID: magnetID,
+                quickMessage: "👋",
+                title: "Wave",
+                systemImage: "hand.wave.fill"
+            )
+
+            quickPostButton(
+                magnetID: magnetID,
+                quickMessage: "❤️",
+                title: "Send love",
+                systemImage: "heart.fill"
+            )
+        }
+    }
+
+    private func quickPostButton(
+        magnetID: UUID,
+        quickMessage: String,
+        title: String,
+        systemImage: String
+    ) -> some View {
+        Button(intent: PostToMagnetIntent(magnetID: magnetID.uuidString, quickMessage: quickMessage)) {
+            HStack(spacing: 10) {
+                Text(quickMessage)
+                    .font(.body)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(title)
+                        .font(.caption.weight(.bold))
+                        .foregroundStyle(.white)
+
+                    Text("Post instantly")
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(.white.opacity(0.68))
+                }
+
+                Spacer(minLength: 8)
+
+                Image(systemName: systemImage)
+                    .font(.caption.weight(.bold))
+                    .foregroundStyle(.white.opacity(0.88))
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 11)
+            .frame(maxWidth: .infinity)
+            .background(.white.opacity(0.12), in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+        }
+        .buttonStyle(.plain)
     }
 }
 

--- a/ios/MagnetsWidget/WidgetViews/MediumWidgetView.swift
+++ b/ios/MagnetsWidget/WidgetViews/MediumWidgetView.swift
@@ -1,3 +1,4 @@
+import AppIntents
 import SwiftUI
 import WidgetKit
 
@@ -19,9 +20,9 @@ struct MediumWidgetView: View {
                     Text(post.displayText)
                         .font(.system(.headline, design: .rounded, weight: .bold))
                         .foregroundStyle(.white)
-                        .lineLimit(4)
+                        .lineLimit(3)
 
-                    Spacer()
+                    Spacer(minLength: 0)
 
                     HStack {
                         Label(post.authorName, systemImage: "person.crop.circle.fill")
@@ -35,14 +36,18 @@ struct MediumWidgetView: View {
                             .foregroundStyle(.white.opacity(0.62))
                     }
                 } else {
-                    Spacer()
+                    Spacer(minLength: 0)
 
                     Text("Add a first note or photo to light up the widget.")
                         .font(.subheadline.weight(.semibold))
                         .foregroundStyle(.white)
                         .lineLimit(3)
 
-                    Spacer()
+                    Spacer(minLength: 0)
+                }
+
+                if let magnetID = entry.magnetID {
+                    quickPostButton(for: magnetID)
                 }
             }
         }
@@ -105,5 +110,28 @@ struct MediumWidgetView: View {
             startPoint: .topLeading,
             endPoint: .bottomTrailing
         )
+    }
+
+    private func quickPostButton(for magnetID: UUID) -> some View {
+        Button(intent: PostToMagnetIntent(magnetID: magnetID.uuidString, quickMessage: "👋")) {
+            HStack(spacing: 10) {
+                Text("👋")
+                    .font(.body)
+
+                Text("Quick post")
+                    .font(.caption.weight(.bold))
+                    .foregroundStyle(.white)
+
+                Spacer(minLength: 8)
+
+                Image(systemName: "paperplane.fill")
+                    .font(.caption.weight(.bold))
+                    .foregroundStyle(.white.opacity(0.88))
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+            .background(.white.opacity(0.14), in: Capsule())
+        }
+        .buttonStyle(.plain)
     }
 }


### PR DESCRIPTION
## What's in this PR

### Interactive Widget Actions
- `PostToMagnetIntent` — AppIntent that posts quick text to a magnet from the widget without opening the app
- Medium widget: 👋 quick-post button
- Large widget: 👋 + ❤️ quick-post buttons
- Widget refreshes immediately after posting
- `openAppWhenRun = false` — stays in widget process
- Existing deep-link tap behavior preserved

### Spec Review: 6/6 FULL PASS
### Build: BUILD SUCCEEDED (Xcode 26.3 / iPhone 17 Pro / iOS 26.2)

4 files changed, 170 additions.